### PR TITLE
Fix typo within main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func (store *URLStore) RedirectHandler(w http.ResponseWriter, r *http.Request) {
 	shortURL := r.URL.Path[1:] // Get the URL path without the leading "/"
 	originalURL, exists := store.RetrieveURL(shortURL)
 	if !exists {
-		http.Error(w, "Short URL not found", http.StatusNotFound)
+		http.Error(w, "Shortened URL not found", http.StatusNotFound)
 		return
 	}
 	http.Redirect(w, r, originalURL, http.StatusFound)


### PR DESCRIPTION
## What
- Typo was fixed in `main.go` . 
## How
- String was modified from `Short` to `Shortened`
## Why 
Users may desire a uniform labelling of components